### PR TITLE
feat: add nicknames, DNS mapping, and cost display

### DIFF
--- a/src/modules/notifications.py
+++ b/src/modules/notifications.py
@@ -13,7 +13,17 @@ except Exception:
 
 
 async def send_notification(
-    bot, action, droplet_name, ip_address, droplet_type, expiration_date, creator_id, duration=None
+    bot,
+    action,
+    droplet_name,
+    ip_address,
+    droplet_type,
+    expiration_date,
+    creator_id,
+    duration=None,
+    creator_username=None,
+    domain_name=None,
+    price_monthly=None,
 ):
     """Send notification to the channel about droplet events."""
     if not NOTIFICATION_CHANNEL_ID:
@@ -21,16 +31,21 @@ async def send_notification(
         return
 
     try:
+        display_name = creator_username or str(creator_id)
         type_label = DROPLET_TYPES.get(droplet_type, droplet_type)
 
         if action == "created":
+            dns_line = f"DNS: {domain_name}\n" if domain_name else ""
+            cost_line = f"Стоимость: ~${price_monthly}/мес\n" if price_monthly else ""
             text = (
                 f"Новый инстанс создан\n\n"
                 f"Имя: {droplet_name}\n"
                 f"IP: {ip_address}\n"
+                f"{dns_line}"
                 f"Тип: {type_label}\n"
+                f"{cost_line}"
                 f"Срок действия: {expiration_date}\n"
-                f"Создатель: {creator_id}"
+                f"Создатель: {display_name}"
             )
         elif action == "extended":
             duration_text = f"\nПродлён на: {duration} дн." if duration else ""
@@ -40,7 +55,7 @@ async def send_notification(
                 f"IP: {ip_address}\n"
                 f"Тип: {type_label}\n"
                 f"Новый срок: {expiration_date}{duration_text}\n"
-                f"Пользователь: {creator_id}"
+                f"Пользователь: {display_name}"
             )
         elif action == "deleted":
             text = (
@@ -48,7 +63,7 @@ async def send_notification(
                 f"Имя: {droplet_name}\n"
                 f"IP: {ip_address}\n"
                 f"Тип: {type_label}\n"
-                f"Пользователь: {creator_id}"
+                f"Пользователь: {display_name}"
             )
         elif action == "auto_deleted":
             text = (
@@ -56,7 +71,7 @@ async def send_notification(
                 f"Имя: {droplet_name}\n"
                 f"IP: {ip_address}\n"
                 f"Тип: {type_label}\n"
-                f"Создатель: {creator_id}"
+                f"Создатель: {display_name}"
             )
         else:
             text = f"Неизвестное действие: {action} для инстанса {droplet_name}"

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -48,3 +48,89 @@ async def test_extended_includes_duration():
         text = bot.send_message.call_args[1]["text"]
         assert "7" in text
         assert "продлён" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_created_shows_username():
+    """Created notification shows creator_username when provided."""
+    with patch("modules.notifications.NOTIFICATION_CHANNEL_ID", "-100123456"):
+        bot = AsyncMock()
+        await send_notification(
+            bot, "created", "my-drop", "1.2.3.4", "s-2vcpu-2gb", "2025-06-01 12:00:00", 42,
+            creator_username="@testuser",
+        )
+        bot.send_message.assert_called_once()
+        text = bot.send_message.call_args[1]["text"]
+        assert "@testuser" in text
+        assert "42" not in text
+
+
+@pytest.mark.asyncio
+async def test_created_falls_back_to_creator_id():
+    """Created notification falls back to creator_id when no username."""
+    with patch("modules.notifications.NOTIFICATION_CHANNEL_ID", "-100123456"):
+        bot = AsyncMock()
+        await send_notification(
+            bot, "created", "my-drop", "1.2.3.4", "s-2vcpu-2gb", "2025-06-01 12:00:00", 42,
+        )
+        bot.send_message.assert_called_once()
+        text = bot.send_message.call_args[1]["text"]
+        assert "42" in text
+
+
+@pytest.mark.asyncio
+async def test_created_shows_dns():
+    """Created notification shows DNS name when provided."""
+    with patch("modules.notifications.NOTIFICATION_CHANNEL_ID", "-100123456"):
+        bot = AsyncMock()
+        await send_notification(
+            bot, "created", "my-drop", "1.2.3.4", "s-2vcpu-2gb", "2025-06-01 12:00:00", 42,
+            domain_name="test.example.com",
+        )
+        bot.send_message.assert_called_once()
+        text = bot.send_message.call_args[1]["text"]
+        assert "test.example.com" in text
+        assert "DNS" in text
+
+
+@pytest.mark.asyncio
+async def test_created_shows_cost():
+    """Created notification shows cost when provided."""
+    with patch("modules.notifications.NOTIFICATION_CHANNEL_ID", "-100123456"):
+        bot = AsyncMock()
+        await send_notification(
+            bot, "created", "my-drop", "1.2.3.4", "s-2vcpu-2gb", "2025-06-01 12:00:00", 42,
+            price_monthly=18.0,
+        )
+        bot.send_message.assert_called_once()
+        text = bot.send_message.call_args[1]["text"]
+        assert "18.0" in text
+        assert "Стоимость" in text
+
+
+@pytest.mark.asyncio
+async def test_deleted_shows_username():
+    """Deleted notification shows creator_username when provided."""
+    with patch("modules.notifications.NOTIFICATION_CHANNEL_ID", "-100123456"):
+        bot = AsyncMock()
+        await send_notification(
+            bot, "deleted", "my-drop", "1.2.3.4", "s-2vcpu-2gb", "2025-06-01 12:00:00", 42,
+            creator_username="@admin",
+        )
+        bot.send_message.assert_called_once()
+        text = bot.send_message.call_args[1]["text"]
+        assert "@admin" in text
+
+
+@pytest.mark.asyncio
+async def test_auto_deleted_shows_username():
+    """Auto-deleted notification shows creator_username when provided."""
+    with patch("modules.notifications.NOTIFICATION_CHANNEL_ID", "-100123456"):
+        bot = AsyncMock()
+        await send_notification(
+            bot, "auto_deleted", "my-drop", "1.2.3.4", "s-2vcpu-2gb", "2025-06-01 12:00:00", 42,
+            creator_username="@admin",
+        )
+        bot.send_message.assert_called_once()
+        text = bot.send_message.call_args[1]["text"]
+        assert "@admin" in text


### PR DESCRIPTION
## Summary

- **User nicknames in notifications**: Show `@username` or `first_name` instead of raw Telegram user IDs in all 4 notification templates (created, extended, deleted, auto_deleted)
- **DNS mapping for new droplets**: New conversation steps (DNS zone selection + subdomain input) during droplet creation. Automatically creates A-records via DO DNS API and cleans them up on deletion. Skip option available if no DNS needed.
- **Cost display**: Fetches live pricing from DO `/v2/sizes` API (cached 1h), shows `$/мес` on type selection buttons and estimated cost per duration. Includes cost in creation notifications.

### Technical changes
- DB schema migration: 4 new columns (`creator_username`, `domain_name`, `dns_record_id`, `dns_zone`) via `_migrate_add_column` helper
- Refactored `get_expiring_instances()` to return `list[dict]` instead of raw tuples
- New API functions: `get_domains()`, `create_dns_record()`, `delete_dns_record()`, `get_sizes()` with TTL cache
- 2 new conversation states (`SELECT_DNS_ZONE`, `INPUT_SUBDOMAIN`) and handlers
- Extracted `_show_droplet_type_keyboard()` helper with pricing integration

## Test plan

- [ ] `ruff check src/ && ruff format --check src/` passes
- [ ] `pytest tests/test_database.py tests/test_notifications.py -v` — 26/26 tests pass
- [ ] Manual: create droplet → verify DNS zone selection appears, subdomain input works, A-record created in DO dashboard
- [ ] Manual: delete droplet → verify DNS record removed from DO dashboard
- [ ] Manual: check notification channel — messages show @username, DNS name, cost
- [ ] Manual: verify "Пропустить (без DNS)" button skips DNS step correctly
- [ ] Manual: verify pricing shows on type/duration buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)