### PR TITLE
feat: DNS-as-name, creator tags, cost tracking, snapshot on expiry

### DIFF
--- a/src/modules/database.py
+++ b/src/modules/database.py
@@ -36,22 +36,45 @@ def init_db():
         _migrate_add_column(connection, "domain_name", "TEXT")
         _migrate_add_column(connection, "dns_record_id", "INTEGER")
         _migrate_add_column(connection, "dns_zone", "TEXT")
+        _migrate_add_column(connection, "created_at", "TEXT")
+        _migrate_add_column(connection, "price_hourly", "REAL")
 
     logger.info("База данных инициализирована.")
 
 
 def save_instance(
-    droplet_id, name, ip_address, droplet_type, expiration_date, ssh_key_id, creator_id, creator_username=None
+    droplet_id,
+    name,
+    ip_address,
+    droplet_type,
+    expiration_date,
+    ssh_key_id,
+    creator_id,
+    creator_username=None,
+    created_at=None,
+    price_hourly=None,
 ):
     """Сохранение информации об инстансе в базу данных."""
     try:
         with sqlite3.connect(DB_PATH) as connection:
             connection.execute(
                 """
-            INSERT INTO instances (droplet_id, name, ip_address, droplet_type, expiration_date, ssh_key_id, creator_id, creator_username)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO instances (droplet_id, name, ip_address, droplet_type, expiration_date, ssh_key_id, creator_id,
+                                   creator_username, created_at, price_hourly)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-                (droplet_id, name, ip_address, droplet_type, expiration_date, ssh_key_id, creator_id, creator_username),
+                (
+                    droplet_id,
+                    name,
+                    ip_address,
+                    droplet_type,
+                    expiration_date,
+                    ssh_key_id,
+                    creator_id,
+                    creator_username,
+                    created_at,
+                    price_hourly,
+                ),
             )
             connection.commit()
         logger.info(f"Инстанс {name} (ID: {droplet_id}) сохранён в базе данных.")
@@ -66,7 +89,7 @@ def get_instance_by_id(droplet_id):
             connection.row_factory = sqlite3.Row
             cursor = connection.execute(
                 "SELECT droplet_id, name, ip_address, droplet_type, expiration_date, ssh_key_id, creator_id, "
-                "creator_username, domain_name, dns_record_id, dns_zone "
+                "creator_username, domain_name, dns_record_id, dns_zone, created_at, price_hourly "
                 "FROM instances WHERE droplet_id = ?",
                 (droplet_id,),
             )
@@ -86,7 +109,7 @@ def get_instances_by_creator(creator_id):
             connection.row_factory = sqlite3.Row
             cursor = connection.execute(
                 "SELECT droplet_id, name, ip_address, droplet_type, expiration_date, ssh_key_id, creator_id, "
-                "creator_username, domain_name, dns_record_id, dns_zone "
+                "creator_username, domain_name, dns_record_id, dns_zone, created_at, price_hourly "
                 "FROM instances WHERE creator_id = ? ORDER BY expiration_date",
                 (creator_id,),
             )
@@ -103,7 +126,8 @@ def get_expiring_instances():
             connection.row_factory = sqlite3.Row
             cursor = connection.execute("""
             SELECT droplet_id, name, ip_address, droplet_type, expiration_date, ssh_key_id, creator_id,
-                   creator_username, domain_name, dns_record_id, dns_zone
+                   creator_username, domain_name, dns_record_id, dns_zone,
+                   created_at, price_hourly
             FROM instances
             WHERE expiration_date <= datetime('now', 'localtime', '+1 day')
             """)

--- a/src/modules/notifications.py
+++ b/src/modules/notifications.py
@@ -73,6 +73,14 @@ async def send_notification(
                 f"Тип: {type_label}\n"
                 f"Создатель: {display_name}"
             )
+        elif action == "snapshot_created":
+            text = (
+                f"Снэпшот создан перед удалением\n\n"
+                f"Имя: {droplet_name}\n"
+                f"IP: {ip_address}\n"
+                f"Тип: {type_label}\n"
+                f"Создатель: {display_name}"
+            )
         else:
             text = f"Неизвестное действие: {action} для инстанса {droplet_name}"
 

--- a/tests/test_create_test_instance.py
+++ b/tests/test_create_test_instance.py
@@ -1,0 +1,32 @@
+from modules.create_test_instance import _sanitize_tag
+
+
+class TestSanitizeTag:
+    def test_strips_at_prefix(self):
+        assert _sanitize_tag("@johndoe") == "johndoe"
+
+    def test_removes_spaces(self):
+        assert _sanitize_tag("First Name") == "FirstName"
+
+    def test_keeps_valid_chars(self):
+        assert _sanitize_tag("user_name-123") == "user_name-123"
+
+    def test_keeps_colons_and_dots(self):
+        assert _sanitize_tag("team:dev.ops") == "team:dev.ops"
+
+    def test_empty_after_clean_returns_unknown(self):
+        assert _sanitize_tag("!!!") == "unknown"
+
+    def test_empty_string_returns_unknown(self):
+        assert _sanitize_tag("") == "unknown"
+
+    def test_truncates_long_input(self):
+        long_tag = "a" * 300
+        result = _sanitize_tag(long_tag)
+        assert len(result) == 255
+
+    def test_unicode_removed(self):
+        assert _sanitize_tag("пользователь") == "unknown"
+
+    def test_mixed_valid_invalid(self):
+        assert _sanitize_tag("@user (admin)") == "useradmin"

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -134,3 +134,19 @@ async def test_auto_deleted_shows_username():
         bot.send_message.assert_called_once()
         text = bot.send_message.call_args[1]["text"]
         assert "@admin" in text
+
+
+@pytest.mark.asyncio
+async def test_snapshot_created_notification():
+    """Snapshot created notification contains expected info."""
+    with patch("modules.notifications.NOTIFICATION_CHANNEL_ID", "-100123456"):
+        bot = AsyncMock()
+        await send_notification(
+            bot, "snapshot_created", "my-drop", "1.2.3.4", "s-2vcpu-2gb", "2025-06-01 12:00:00", 42,
+            creator_username="@admin",
+        )
+        bot.send_message.assert_called_once()
+        text = bot.send_message.call_args[1]["text"]
+        assert "Снэпшот" in text
+        assert "my-drop" in text
+        assert "@admin" in text


### PR DESCRIPTION
## Summary

- **DNS as droplet name**: When DNS mapping is selected, the FQDN (`subdomain.zone`) is automatically used as the droplet name, skipping the manual name input step
- **Creator tags**: Droplets are tagged with `creator:{username}` in DigitalOcean for easier identification
- **Cost tracking**: "Manage droplets" view now shows accumulated cost (`Потрачено: ~$X.XX`) calculated from `created_at` and `price_hourly` stored in the DB
- **Snapshot on expiry**: Before auto-deleting expired droplets, a snapshot (`{name}-expired-{date}`) is created with a 10-minute timeout; failures are logged but don't block deletion
- **Snapshot notification**: New `snapshot_created` channel notification action
- **DB migration**: Added `created_at` (TEXT) and `price_hourly` (REAL) columns to `instances` table with backward compatibility for existing rows

## Test plan

- [x] Lint passes (`ruff check src/ && ruff format --check src/`)
- [x] All 59 tests pass (`pytest tests/ -v`) — 14 new tests added
- [ ] Verify droplet creation with DNS selected skips name input and uses FQDN
- [ ] Verify droplet creation without DNS still prompts for manual name
- [ ] Verify `creator:{username}` tag appears on new droplets in DO dashboard
- [ ] Verify "Manage droplets" shows cost line for newly created droplets
- [ ] Verify old droplets (without `created_at`) gracefully skip cost display
- [ ] Verify snapshot is created before auto-deletion of expired droplets

🤖 Generated with [Claude Code](https://claude.com/claude-code)