### PR TITLE
feat: multi-select SSH keys + auto-tag droplets

### DIFF
--- a/src/modules/create_test_instance.py
+++ b/src/modules/create_test_instance.py
@@ -161,7 +161,7 @@ async def get_sizes(token):
 async def create_droplet(
     token,
     name,
-    ssh_key_id,
+    ssh_key_ids,
     droplet_type,
     image,
     duration,
@@ -179,13 +179,15 @@ async def create_droplet(
             "region": "fra1",
             "size": droplet_type,
             "image": image,
-            "ssh_keys": [ssh_key_id],
+            "ssh_keys": ssh_key_ids if isinstance(ssh_key_ids, list) else [ssh_key_ids],
             "backups": False,
             "ipv6": True,
             "monitoring": True,
         }
+        tags = ["createdby:telegram-admin-bot"]
         if creator_tag:
-            payload["tags"] = [f"creator:{_sanitize_tag(creator_tag)}"]
+            tags.append(f"creator:{_sanitize_tag(creator_tag)}")
+        payload["tags"] = tags
 
         headers = {**_auth_headers(token), "Content-Type": "application/json"}
 
@@ -214,13 +216,14 @@ async def create_droplet(
 
         # Сохраняем данные в БД
         created_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        key_ids = ssh_key_ids if isinstance(ssh_key_ids, list) else [ssh_key_ids]
         save_instance(
             droplet_id,
             name,
             ip_address,
             droplet_type,
             expiration_date,
-            ssh_key_id,
+            key_ids[0] if key_ids else None,
             creator_id,
             creator_username,
             created_at=created_at,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,59 @@
+from bot import _build_ssh_key_keyboard
+
+
+def _make_keys(n):
+    return [{"id": i + 1, "name": f"key{i + 1}"} for i in range(n)]
+
+
+class TestBuildSshKeyKeyboard:
+    def test_3_keys_all_selected_no_expand(self):
+        keys = _make_keys(3)
+        markup = _build_ssh_key_keyboard(keys, {"1", "2", "3"}, expanded=False)
+        rows = markup.inline_keyboard
+        assert len(rows) == 4  # 3 key rows + 1 confirm
+        # No "Другие ключи" button anywhere
+        all_texts = [btn.text for row in rows for btn in row]
+        assert not any("Другие ключи" in t for t in all_texts)
+
+    def test_5_keys_collapsed(self):
+        keys = _make_keys(5)
+        markup = _build_ssh_key_keyboard(keys, {"1", "2", "3"}, expanded=False)
+        rows = markup.inline_keyboard
+        assert len(rows) == 5  # 3 key rows + 1 expand + 1 confirm
+        expand_btn = rows[3][0]
+        assert "Другие ключи" in expand_btn.text
+        assert "(2)" in expand_btn.text
+        assert expand_btn.callback_data == "ssh_more_keys"
+
+    def test_5_keys_expanded(self):
+        keys = _make_keys(5)
+        markup = _build_ssh_key_keyboard(keys, {"1", "2", "3"}, expanded=True)
+        rows = markup.inline_keyboard
+        assert len(rows) == 6  # 5 key rows + 1 confirm
+        all_texts = [btn.text for row in rows for btn in row]
+        assert not any("Другие ключи" in t for t in all_texts)
+
+    def test_selected_checkmark_prefix(self):
+        keys = _make_keys(1)
+        markup = _build_ssh_key_keyboard(keys, {"1"}, expanded=False)
+        btn = markup.inline_keyboard[0][0]
+        assert btn.text.startswith("✅")
+
+    def test_unselected_empty_prefix(self):
+        keys = _make_keys(1)
+        markup = _build_ssh_key_keyboard(keys, set(), expanded=False)
+        btn = markup.inline_keyboard[0][0]
+        assert btn.text.startswith("⬜")
+
+    def test_confirm_shows_count(self):
+        keys = _make_keys(3)
+        markup = _build_ssh_key_keyboard(keys, {"1", "3"}, expanded=False)
+        confirm_btn = markup.inline_keyboard[-1][0]
+        assert "(2)" in confirm_btn.text
+        assert confirm_btn.callback_data == "ssh_confirm"
+
+    def test_single_key(self):
+        keys = _make_keys(1)
+        markup = _build_ssh_key_keyboard(keys, {"1"}, expanded=False)
+        rows = markup.inline_keyboard
+        assert len(rows) == 2  # 1 key row + 1 confirm

--- a/tests/test_create_test_instance.py
+++ b/tests/test_create_test_instance.py
@@ -1,4 +1,7 @@
-from modules.create_test_instance import _sanitize_tag
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from modules.create_test_instance import _sanitize_tag, create_droplet
 
 
 class TestSanitizeTag:
@@ -30,3 +33,80 @@ class TestSanitizeTag:
 
     def test_mixed_valid_invalid(self):
         assert _sanitize_tag("@user (admin)") == "useradmin"
+
+
+def _make_mock_client():
+    """Create a mock httpx.AsyncClient that captures POST payload."""
+    mock_client = AsyncMock()
+
+    # POST response — droplet created
+    post_response = MagicMock()
+    post_response.json.return_value = {
+        "droplet": {"id": 12345, "name": "test-droplet"}
+    }
+    post_response.raise_for_status = MagicMock()
+    mock_client.post.return_value = post_response
+
+    # GET response — IP polling (returns IP immediately)
+    get_response = MagicMock()
+    get_response.json.return_value = {
+        "droplet": {
+            "networks": {
+                "v4": [{"ip_address": "1.2.3.4"}]
+            }
+        }
+    }
+    get_response.raise_for_status = MagicMock()
+    mock_client.get.return_value = get_response
+
+    return mock_client
+
+
+@pytest.mark.asyncio
+class TestCreateDropletTags:
+    """Tests for create_droplet tagging behavior."""
+
+    @patch("modules.create_test_instance.save_instance")
+    async def test_createdby_tag_always_present(self, mock_save):
+        mock_client = _make_mock_client()
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_client
+
+        with patch("httpx.AsyncClient", return_value=mock_ctx):
+            await create_droplet(
+                token="fake-token",
+                name="test",
+                ssh_key_ids=[123],
+                droplet_type="s-2vcpu-2gb",
+                image="ubuntu-22-04-x64",
+                duration=1,
+                creator_id=111,
+                creator_tag="testuser",
+            )
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert "createdby:telegram-admin-bot" in payload["tags"]
+        assert "creator:testuser" in payload["tags"]
+
+    @patch("modules.create_test_instance.save_instance")
+    async def test_createdby_tag_without_creator(self, mock_save):
+        mock_client = _make_mock_client()
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_client
+
+        with patch("httpx.AsyncClient", return_value=mock_ctx):
+            await create_droplet(
+                token="fake-token",
+                name="test",
+                ssh_key_ids=[123],
+                droplet_type="s-2vcpu-2gb",
+                image="ubuntu-22-04-x64",
+                duration=1,
+                creator_id=111,
+                creator_tag=None,
+            )
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["tags"] == ["createdby:telegram-admin-bot"]


### PR DESCRIPTION
## Summary
- **SSH key multi-select UI**: Droplet creation now shows a multi-select picker with first 3 keys preselected (✅/⬜ toggles), collapsible "Другие ключи" for 4+ keys, and a "Продолжить ✓ (N)" confirm button with empty-selection validation
- **Droplet tagging**: Every created droplet is now automatically tagged with `createdby:telegram-admin-bot` alongside the existing `creator:username` tag
- **`ssh_key_ids` param**: `create_droplet()` accepts a list of SSH key IDs instead of a single ID, enabling multiple keys per droplet

## Test plan
- [ ] `ruff check src/` and `ruff format --check src/` pass
- [ ] `pytest tests/ -v` — 68 tests pass (7 new keyboard builder tests + 2 new tag tests)
- [ ] Manual: start droplet creation, verify first 3 SSH keys shown with ✅, "Другие ключи" appears if >3 keys
- [ ] Manual: toggle keys, expand list, confirm with 0 keys (alert), confirm with ≥1 key (proceeds)
- [ ] Manual: verify created droplet has both `createdby:telegram-admin-bot` and `creator:username` tags in DO console

🤖 Generated with [Claude Code](https://claude.com/claude-code)