### PR TITLE
fix: disable IPv6 on new droplets

### DIFF
--- a/src/modules/create_test_instance.py
+++ b/src/modules/create_test_instance.py
@@ -181,7 +181,7 @@ async def create_droplet(
             "image": image,
             "ssh_keys": ssh_key_ids if isinstance(ssh_key_ids, list) else [ssh_key_ids],
             "backups": False,
-            "ipv6": True,
+            "ipv6": False,
             "monitoring": True,
         }
         tags = ["createdby:telegram-admin-bot"]


### PR DESCRIPTION
## Summary
- Disabled IPv6 on newly created DigitalOcean droplets by setting `"ipv6": False` in the API payload

## Test plan
- [x] `ruff check src/` passes
- [x] `ruff format --check src/` passes
- [ ] Create a test droplet and verify IPv6 is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)